### PR TITLE
Customer Order and Movement Bugfixes

### DIFF
--- a/Assets/Code/CustomerMovement.cs
+++ b/Assets/Code/CustomerMovement.cs
@@ -7,7 +7,7 @@ public class CustomerMovement : MonoBehaviour
     public float speed = 1f;
     private float moveForce = 0f;
 
-    private bool wasAtCounter = false;
+    //private bool wasAtCounter = false;
 
     // Editor variables
     public Rigidbody2D rigid;
@@ -40,16 +40,15 @@ public class CustomerMovement : MonoBehaviour
 
     private void OnTriggerEnter2D(Collider2D collision)
     {
-        // Freeze the customer's momentum the first time the customer collides with anything.
-        // Change this to happen only when colliding with a counter trigger tag.
-        if (!wasAtCounter)
+        // Only stop moving if the collision has the Counter tag
+        if (collision.gameObject.CompareTag("Counter"))
         {
             Debug.Log("Customer is at counter");
             moveForce = 0f;
 
             rigid.constraints = RigidbodyConstraints2D.FreezePosition;
             rigid.constraints = RigidbodyConstraints2D.FreezePositionY;
-            wasAtCounter = true;
+            //wasAtCounter = true;
         }
     }
 }

--- a/Assets/Code/CustomerOrder.cs
+++ b/Assets/Code/CustomerOrder.cs
@@ -46,20 +46,24 @@ public class CustomerOrder : MonoBehaviour
             timeSinceOrderTaken += Time.deltaTime;
         }
     }
-
+    
+    // Take Order
     private void OnTriggerEnter2D(Collider2D collision)
     {
-        Debug.Log("Player near customer");
-        if ( orderTaken == false )
+        // Check if the collision has the tag Player
+        if (collision.gameObject.CompareTag("Player"))
         {
-            GenerateNewOrder();
-            orderTaken = true;
+            Debug.Log("Player near customer");
+            if (orderTaken == false)
+            {
+                GenerateNewOrder();
+                orderTaken = true;
+            }
+            else
+            {
+                ReceiveOrder();
+            }
         }
-        else
-        {
-            ReceiveOrder();
-        }
-
     }
 
 


### PR DESCRIPTION
Customer now only stops when it's collision has the "Counter" tag. (This means that the customer will fly across the map unless the tag "Counter" is added to the location of the counter.)

Issues:
The player needs to go around the counter in order to generate or receive an order. This could be fixed by using a bigger collider on the customer or player, or by adding another collider.

Bug fixes:
The customer only takes the order from the player with the "Player" tag instead of anything it collides with. (This means that the player now requires the "Player" tag in order to generate or receive parts of an order.)