### PR TITLE
Fixed Soda Can Mechanic

### DIFF
--- a/Assets/Prefabs/7Up/DrinkSpillStuff.cs
+++ b/Assets/Prefabs/7Up/DrinkSpillStuff.cs
@@ -61,7 +61,7 @@ public class DrinkSpillStuff : MonoBehaviour {
 
         animator.SetTrigger("clean");
         yield return new WaitForSeconds(1);
-        stage = 0;
+        stage = 3;
         yield return new WaitForSeconds(5);
         gameObject.SetActive(false);
     }

--- a/Assets/Prefabs/7Up/drinkSpill.prefab
+++ b/Assets/Prefabs/7Up/drinkSpill.prefab
@@ -103,7 +103,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1641090068
 Transform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Bug Fixes:
Fixed the collision being bigger than it should be. (The player could previously interact with the can on the floor. This is fixed so the player can only interact with the floor when the drink is spilled.)

Stopped the player from re-opening the drink (Previously the can was reset back to stage 0 after the can is spilled in stage 0, allowing the can to be reopened. This is fixed by setting the can to an unused stage 3 after spilled.)